### PR TITLE
fix: select newest Wayback snapshot that still has content

### DIFF
--- a/src/lib/server/cdx.test.ts
+++ b/src/lib/server/cdx.test.ts
@@ -1,85 +1,108 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { resolveTimestamp } from './cdx';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resolveTimestamp, resolveTimestamps } from './cdx';
 import { clear } from './cache';
 
-describe('resolveTimestamp', () => {
+const WS_WINDOWS_URL = 'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml';
+const GZ_URL = 'https://softwareupdate.vmware.com/cds/vmw-desktop/ws/17.0.0/metadata.xml.gz';
+
+function row(timestamp: string) {
+	return [
+		'com,vmware,softwareupdate)/cds/vmw-desktop/ws-windows.xml',
+		timestamp,
+		WS_WINDOWS_URL,
+		'application/xml',
+		'200',
+		'DIGEST',
+		'897'
+	];
+}
+
+const HEADER = ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'];
+
+function mockCdx(rows: string[][]) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve([HEADER, ...rows])
+		})
+	);
+}
+
+describe('resolveTimestamps', () => {
 	beforeEach(() => {
 		clear();
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockResolvedValue({
-				ok: true,
-				json: () =>
-					Promise.resolve([
-						['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
-						[
-							'com,vmware,softwareupdate)/cds/vmw-desktop/ws-windows.xml',
-							'20241003182329',
-							'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
-							'application/xml',
-							'200',
-							'DIGEST',
-							'897'
-						]
-					])
-			})
-		);
+		mockCdx([row('20240913183755'), row('20241003182329'), row('20250221215224')]);
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	it('returns timestamp from CDX API response', async () => {
-		const ts = await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
-			'product-xml'
-		);
-		expect(ts).toBe('20241003182329');
+	it('returns CDX timestamps newest first', async () => {
+		const ts = await resolveTimestamps(WS_WINDOWS_URL, 'product-xml');
+		expect(ts).toEqual(['20250221215224', '20241003182329', '20240913183755']);
 	});
 
-	it('caches the timestamp on subsequent calls', async () => {
-		await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
-			'product-xml'
-		);
-		await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
-			'product-xml'
-		);
+	it('keeps only the newest `limit` timestamps', async () => {
+		const ts = await resolveTimestamps(WS_WINDOWS_URL, 'product-xml', 2);
+		expect(ts).toEqual(['20250221215224', '20241003182329']);
+	});
+
+	it('caches the timestamps on subsequent calls', async () => {
+		await resolveTimestamps(WS_WINDOWS_URL, 'product-xml');
+		await resolveTimestamps(WS_WINDOWS_URL, 'product-xml');
 		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
-	it('returns fallback timestamp when CDX API fails', async () => {
+	it('returns the per-product fallback when the CDX API fails', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
-		const ts = await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
-			'product-xml'
-		);
-		expect(ts).toBe('20241003182329');
+		expect(await resolveTimestamps(WS_WINDOWS_URL, 'product-xml')).toEqual(['20250221215224']);
+		expect(
+			await resolveTimestamps(
+				'https://softwareupdate.vmware.com/cds/vmw-desktop/player-linux.xml',
+				'product-xml'
+			)
+		).toEqual(['20250313181114']);
 	});
 
-	it('returns fallback timestamp when CDX returns empty results', async () => {
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockResolvedValue({
-				ok: true,
-				json: () => Promise.resolve([['urlkey', 'timestamp', 'original']])
-			})
-		);
-		const ts = await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws-windows.xml',
+	it('returns the default product fallback for an unknown XML file', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+		const ts = await resolveTimestamps(
+			'https://softwareupdate.vmware.com/cds/vmw-desktop/unknown.xml',
 			'product-xml'
 		);
-		expect(ts).toBe('20241003182329');
+		expect(ts).toEqual(['20250221215224']);
 	});
 
-	it('returns metadata-gz fallback for that category', async () => {
+	it('returns the fallback when CDX returns no rows', async () => {
+		mockCdx([]);
+		const ts = await resolveTimestamps(WS_WINDOWS_URL, 'product-xml');
+		expect(ts).toEqual(['20250221215224']);
+	});
+
+	it('returns the metadata-gz fallback for that category', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('timeout')));
-		const ts = await resolveTimestamp(
-			'https://softwareupdate.vmware.com/cds/vmw-desktop/ws/17.0.0/metadata.xml.gz',
-			'metadata-gz'
-		);
-		expect(ts).toBe('20240910091207');
+		expect(await resolveTimestamps(GZ_URL, 'metadata-gz')).toEqual(['20240910091207']);
+	});
+});
+
+describe('resolveTimestamp', () => {
+	beforeEach(() => {
+		clear();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns the newest timestamp', async () => {
+		mockCdx([row('20241003182329'), row('20250221215224')]);
+		expect(await resolveTimestamp(WS_WINDOWS_URL, 'product-xml')).toBe('20250221215224');
+	});
+
+	it('returns the fallback when the CDX API fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+		expect(await resolveTimestamp(GZ_URL, 'metadata-gz')).toBe('20240910091207');
 	});
 });

--- a/src/lib/server/cdx.ts
+++ b/src/lib/server/cdx.ts
@@ -3,29 +3,54 @@ import * as cache from './cache';
 const CDX_BASE = 'https://web.archive.org/cdx/search/cdx';
 const CDX_TIMEOUT = 5000;
 const CDX_CACHE_PREFIX = 'cdx:';
+const DEFAULT_LIMIT = 5;
 
-const FALLBACK_TIMESTAMPS: Record<string, string> = {
-	'product-xml': '20241003182329',
-	'metadata-gz': '20240910091207'
+const METADATA_GZ_FALLBACK = '20240910091207';
+const PRODUCT_XML_DEFAULT_FALLBACK = '20250221215224';
+
+/**
+ * Newest capture of each product XML that still lists non-info-only entries.
+ * Broadcom gutted the upstream index in late 2025, so later snapshots archive a
+ * stub that fails validateProductXml.
+ */
+const PRODUCT_XML_FALLBACKS: Record<string, string> = {
+	'ws-windows.xml': '20250221215224',
+	'ws-linux.xml': '20250221215227',
+	'fusion-universal.xml': '20250221215237',
+	'fusion-arm64.xml': '20250114162940',
+	'fusion.xml': '20250114135635',
+	'player-linux.xml': '20250313181114',
+	'player-windows.xml': '20250221215240',
+	'vmrc-linux.xml': '20241125113204',
+	'vmrc-macos.xml': '20250114215343',
+	'vmrc-windows.xml': '20241119045703'
 };
 
-export async function resolveTimestamp(
+function fallbackFor(url: string, category: 'product-xml' | 'metadata-gz'): string[] {
+	if (category === 'metadata-gz') return [METADATA_GZ_FALLBACK];
+	const fileName = url.split('/').pop() ?? '';
+	return [PRODUCT_XML_FALLBACKS[fileName] ?? PRODUCT_XML_DEFAULT_FALLBACK];
+}
+
+/**
+ * Candidate Wayback timestamps for a URL, newest first. Callers are expected to
+ * try them in order and keep the first whose payload passes validation.
+ */
+export async function resolveTimestamps(
 	url: string,
-	category: 'product-xml' | 'metadata-gz'
-): Promise<string> {
+	category: 'product-xml' | 'metadata-gz',
+	limit: number = DEFAULT_LIMIT
+): Promise<string[]> {
 	const cacheKey = `${CDX_CACHE_PREFIX}${url}`;
-	const cached = cache.get<string>(cacheKey);
+	const cached = cache.get<string[]>(cacheKey);
 	if (cached) return cached;
 
 	try {
 		const params = new URLSearchParams({
 			url,
 			output: 'json',
-			limit: '1',
 			filter: 'statuscode:200',
-			from: '20240101',
-			sort: 'closest',
-			order: 'desc'
+			from: '20240101'
 		});
 		const response = await fetch(`${CDX_BASE}?${params}`, {
 			signal: AbortSignal.timeout(CDX_TIMEOUT)
@@ -34,13 +59,26 @@ export async function resolveTimestamp(
 		if (!response.ok) throw new Error(`CDX API returned ${response.status}`);
 
 		const data = (await response.json()) as string[][];
-		if (data.length >= 2 && data[1].length >= 2) {
-			const timestamp = data[1][1];
-			cache.set(cacheKey, timestamp);
-			return timestamp;
-		}
-		throw new Error('No snapshots found');
+		const timestamps = data
+			.slice(1)
+			.filter((row) => row.length >= 2)
+			.map((row) => row[1])
+			.slice(-limit)
+			.reverse();
+
+		if (timestamps.length === 0) throw new Error('No snapshots found');
+
+		cache.set(cacheKey, timestamps);
+		return timestamps;
 	} catch {
-		return FALLBACK_TIMESTAMPS[category];
+		return fallbackFor(url, category);
 	}
+}
+
+export async function resolveTimestamp(
+	url: string,
+	category: 'product-xml' | 'metadata-gz'
+): Promise<string> {
+	const timestamps = await resolveTimestamps(url, category);
+	return timestamps[0];
 }

--- a/src/lib/server/sources.test.ts
+++ b/src/lib/server/sources.test.ts
@@ -13,7 +13,8 @@ function mockFetchSequence(responses: Array<{ ok?: boolean; data?: string; error
 			return Promise.resolve({
 				ok: resp.ok,
 				status: resp.ok ? 200 : 500,
-				arrayBuffer: () => Promise.resolve(new TextEncoder().encode(resp.data ?? '').buffer)
+				arrayBuffer: () => Promise.resolve(new TextEncoder().encode(resp.data ?? '').buffer),
+				json: () => Promise.resolve(JSON.parse(resp.data ?? 'null'))
 			});
 		})
 	);
@@ -81,6 +82,52 @@ describe('fetchWithFallback', () => {
 			expect((e as FetchError).attempts).toHaveLength(3);
 			expect((e as FetchError).attempts.every((a) => a.status === 'failed')).toBe(true);
 		}
+	});
+
+	it('skips Wayback snapshots that fail validation and uses the next one', async () => {
+		const validator = (data: ArrayBuffer) => new TextDecoder().decode(data).includes('good');
+		mockFetchSequence([
+			{ ok: true, data: 'bad live' },
+			{ ok: true, data: 'bad live' },
+			// CDX API call
+			{
+				ok: true,
+				data: JSON.stringify([
+					['urlkey', 'timestamp'],
+					['x', '20241003182329'],
+					['x', '20250221215224']
+				])
+			},
+			// newest snapshot: stub with no usable content
+			{ ok: true, data: 'bad archived' },
+			// next-newest snapshot: real content
+			{ ok: true, data: 'good archived' }
+		]);
+
+		const result = await fetchWithFallback('ws-windows.xml', validator);
+		expect(result.sourceName).toBe('Wayback Machine');
+		expect(result.timestamp).toBe('20241003182329');
+		expect(result.attempts).toHaveLength(3);
+		expect(result.attempts[2].status).toBe('success');
+	});
+
+	it('throws FetchError when every Wayback snapshot fails validation', async () => {
+		const validator = (data: ArrayBuffer) => new TextDecoder().decode(data).includes('good');
+		mockFetchSequence([
+			{ ok: true, data: 'bad live' },
+			{ ok: true, data: 'bad live' },
+			{
+				ok: true,
+				data: JSON.stringify([
+					['urlkey', 'timestamp'],
+					['x', '20241003182329'],
+					['x', '20250221215224']
+				])
+			},
+			{ ok: true, data: 'bad archived' }
+		]);
+
+		await expect(fetchWithFallback('ws-windows.xml', validator)).rejects.toBeInstanceOf(FetchError);
 	});
 
 	it('rejects source when validation fails and tries next', async () => {

--- a/src/lib/server/sources.ts
+++ b/src/lib/server/sources.ts
@@ -1,4 +1,4 @@
-import { resolveTimestamp } from './cdx';
+import { resolveTimestamps } from './cdx';
 import type { SourceAttempt } from '../types';
 
 const SOURCES = [
@@ -49,21 +49,23 @@ export async function fetchWithFallback(
 	}
 
 	const start = Date.now();
-	try {
-		const fullUrl = `${WAYBACK_ORIGINAL_BASE}${path}`;
-		const timestamp = await resolveTimestamp(fullUrl, cdxCategory);
-		const waybackUrl = `${WAYBACK_BASE}${timestamp}id_/${fullUrl}`;
-		const response = await fetch(waybackUrl, {
-			signal: AbortSignal.timeout(WAYBACK_TIMEOUT)
-		});
-		if (!response.ok) throw new Error(`HTTP ${response.status}`);
-		const data = await response.arrayBuffer();
-		if (validate && !validate(data)) throw new Error('Validation failed');
-		attempts.push({ name: 'Wayback Machine', status: 'success', ms: Date.now() - start });
-		return { data, sourceName: 'Wayback Machine', timestamp, attempts };
-	} catch {
-		attempts.push({ name: 'Wayback Machine', status: 'failed', ms: Date.now() - start });
+	const fullUrl = `${WAYBACK_ORIGINAL_BASE}${path}`;
+	for (const timestamp of await resolveTimestamps(fullUrl, cdxCategory)) {
+		try {
+			const waybackUrl = `${WAYBACK_BASE}${timestamp}id_/${fullUrl}`;
+			const response = await fetch(waybackUrl, {
+				signal: AbortSignal.timeout(WAYBACK_TIMEOUT)
+			});
+			if (!response.ok) throw new Error(`HTTP ${response.status}`);
+			const data = await response.arrayBuffer();
+			if (validate && !validate(data)) throw new Error('Validation failed');
+			attempts.push({ name: 'Wayback Machine', status: 'success', ms: Date.now() - start });
+			return { data, sourceName: 'Wayback Machine', timestamp, attempts };
+		} catch {
+			continue;
+		}
 	}
+	attempts.push({ name: 'Wayback Machine', status: 'failed', ms: Date.now() - start });
 
 	throw new FetchError('All sources failed', attempts);
 }


### PR DESCRIPTION
Broadcom gutted the upstream CDS index in late 2025. Both live sources and the newest Wayback captures now return a stub listing only an info-only entry, which validateProductXml rejects, so /api/products/*/versions returned 502 for most products whenever the CDX API responded.

Resolve a list of candidate timestamps newest-first instead of a single one, and let fetchWithFallback keep the first snapshot whose payload passes the caller's validator. Drop the sort and order parameters from the CDX query; order was not a CDX parameter at all.

Refresh the fallback timestamps used when CDX times out. They are now per product XML and point at the newest capture verified to list non-info-only entries, which recovers 17.6.1 through 17.6.3. The metadata.xml.gz fallback is unchanged.

Also give the sources test fetch mock a json method. Without it every CDX call in those tests threw and silently exercised the fallback path.