### PR TITLE
fix: let Dependabot track npm deps and relock deno.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'deno'
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'

--- a/.github/workflows/dependabot-relock.yml
+++ b/.github/workflows/dependabot-relock.yml
@@ -1,0 +1,44 @@
+name: Relock Deno
+
+# Dependabot updates package.json only; deno.lock must be regenerated in the
+# same PR or the frozen install in CI fails.
+on:
+  pull_request_target:
+    branches: [main]
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+concurrency:
+  group: relock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  relock:
+    name: Regenerate deno.lock
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - run: deno install
+
+      - name: Commit deno.lock
+        run: |
+          if git diff --quiet -- deno.lock; then
+            echo "deno.lock already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add deno.lock
+          git commit -m "chore: update deno.lock"
+          git push


### PR DESCRIPTION
Dependabot's `deno` ecosystem requires a `deno.json`/`deno.jsonc` manifest, which this repo does not have, so the config matched nothing and no dependency PRs were opened after the bun to deno migration.

- Switch the ecosystem to `npm`, which reads `package.json` directly.
- Add a workflow that regenerates and commits `deno.lock` on Dependabot PRs, so `deno install --frozen` keeps passing.

The relock job needs `pull_request_target` with write access because Dependabot PRs get a read-only token; it is restricted to `dependabot[bot]` on same-repo branches and does not run the local composite action from the PR checkout.